### PR TITLE
Bundle layer request

### DIFF
--- a/src/graphqlqueries/Layers.ts
+++ b/src/graphqlqueries/Layers.ts
@@ -1,0 +1,9 @@
+export const allLayersByIds = `query($ids: [Int]) {
+  allLayersByIds(ids: $ids) {
+    id
+    clientConfig
+    name
+    sourceConfig
+    type
+  }
+}`;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -36,10 +36,10 @@ import SHOGunAPIClient from '../service/SHOGunAPIClient';
 
 import { getBearerTokenHeader } from '../security/getBearerTokenHeader';
 
-
 import {
   allLayersByIds
 } from '../graphqlqueries/Layers';
+
 export interface SHOGunApplicationUtilOpts {
   client?: SHOGunAPIClient;
 }
@@ -105,14 +105,14 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       return;
     }
 
-    let applicationLayerIds: number[] = this.getLayerIds(layerTree.children);
+    let layerIds: number[] = this.getLayerIds(layerTree.children);
 
-    if (applicationLayerIds.length > 0) {
+    if (layerIds.length > 0) {
       try {
         const { allLayersByIds: layers } = await this.client.graphql().sendQuery<Layer>({
           query: allLayersByIds,
           variables: {
-            ids: applicationLayerIds
+            ids: layerIds
           }
         });
         if (layerTree.children) {

--- a/src/service/GraphQLService/index.spec.ts
+++ b/src/service/GraphQLService/index.spec.ts
@@ -54,8 +54,7 @@ describe('GraphQLService', () => {
 
     const result = await service.sendQuery<User>(graphqlQuery);
 
-    expect(result.errors).toBeUndefined();
-    expect(result.data).toEqual(expected);
+    expect(result).toEqual(expected);
   });
 
   it('throws an error if the endpoint returns an errenous status code', async () => {

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -33,7 +33,7 @@ export class GraphQLService {
     this.keycloak = opts.keycloak;
   }
 
-  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<GraphQLResponse<T>> {
+  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<any> {
     try {
       const response = await fetch(this.basePath, {
         method: 'POST',
@@ -46,17 +46,17 @@ export class GraphQLService {
         ...fetchOpts
       });
 
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
+      if (!response?.ok) {
+        throw new Error(`HTTP error status: ${response?.status}`);
       }
 
-      const responseJson = await response.json() as GraphQLResponse<T>;
+      const {data, errors } = await response.json() as GraphQLResponse<T>;
 
-      if (responseJson.errors?.length > 0) {
-        throw new Error(`Error response: ${responseJson.errors}`);
+      if (errors?.length > 0) {
+        throw new Error(`Error response: ${errors}`);
       }
 
-      return responseJson;
+      return data;
     } catch (error) {
       throw new Error(`Error while requesting GraphQL: ${error}`);
     }

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -12,7 +12,7 @@ export interface GraphQLQueryObject {
 
 export interface GraphQLResponse<T> {
   data: {
-    [key: string]: T[]
+    [key: string]: T[];
   };
   errors?: any;
 };

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -11,7 +11,9 @@ export interface GraphQLQueryObject {
 };
 
 export interface GraphQLResponse<T> {
-  data: T[];
+  data: {
+    [key: string]: T[]
+  };
   errors?: any;
 };
 
@@ -33,7 +35,7 @@ export class GraphQLService {
     this.keycloak = opts.keycloak;
   }
 
-  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<any> {
+  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<{[key: string]: T[]}> {
     try {
       const response = await fetch(this.basePath, {
         method: 'POST',


### PR DESCRIPTION
### Breaking change

* Fetch all configured application layers at once via `allLayersByIds` query
* Add some tests and null checks

Introduces breaking change due to modification of `parseNodes` and `parseFolder` method arguments.

Both methods are expecting a mandatory array of layer entities as second argument.

Old signature:
```
parseNodes(nodes: DefaultLayerTree[], projection?: OlProjectionLike)
parseFolder(nodes: DefaultLayerTree[], projection?: OlProjectionLike)
```

New signature: 
```
parseNodes(nodes: DefaultLayerTree[], layers: Layer[], projection?: OlProjectionLike)
parseFolder(nodes: DefaultLayerTree[], layers: Layer[], projection?: OlProjectionLike)
```
Please review @terrestris/devs 