### PR TITLE
Move transparent param to requestParam map

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -2,6 +2,10 @@ import { FeatureCollection } from 'geojson';
 import BaseEntity, { BaseEntityArgs } from './BaseEntity';
 import LayerType from './enum/LayerType';
 
+export interface DefaultRequestParams {
+  transparent?: boolean;
+}
+
 export interface DefaultLayerSourceConfig {
   url: string;
   layerNames: string;
@@ -10,7 +14,7 @@ export interface DefaultLayerSourceConfig {
   tileOrigin?: [number, number];
   resolutions?: number[];
   attribution?: string;
-  transparent?: boolean;
+  requestParams?: DefaultRequestParams;
 }
 
 export interface DefaultLayerPropertyConfig {

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -202,7 +202,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
-      transparent
+      requestParams
     } = layer.sourceConfig || {};
 
     const {
@@ -216,7 +216,10 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attributions: attribution,
       params: {
         'LAYERS': layerNames,
-        'TRANSPARENT': transparent !== undefined ? transparent : true
+        'TRANSPARENT':
+          requestParams?.transparent !== undefined
+            ? requestParams?.transparent
+            : true
       },
       crossOrigin,
       imageLoadFunction: this.bearerTokenLoadFunction
@@ -241,7 +244,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       tileSize = 256,
       tileOrigin,
       resolutions,
-      transparent
+      requestParams
     } = layer.sourceConfig || {};
 
     const {
@@ -266,7 +269,10 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       projection,
       params: {
         'LAYERS': layerNames,
-        'TRANSPARENT': transparent !== undefined ? transparent : true
+        'TRANSPARENT':
+          requestParams?.transparent !== undefined
+            ? requestParams?.transparent
+            : true
       },
       crossOrigin,
       tileLoadFunction: this.bearerTokenLoadFunction
@@ -396,7 +402,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     olLayer.set('propertyConfig', layer.clientConfig?.propertyConfig);
     olLayer.set('legendUrl', layer.sourceConfig.legendUrl);
     olLayer.set('hoverable', layer.clientConfig?.hoverable);
-    olLayer.set('transparent', layer.sourceConfig?.transparent);
+    olLayer.set('transparent', layer.sourceConfig?.requestParams?.transparent);
   }
 
   private async bearerTokenLoadFunctionVector(opts: {


### PR DESCRIPTION
# Fix

Provides the processing of the `sourceConfig` parameter `requestParams` (for TRANSPAREN and other params in perspective) . The [previously](https://github.com/terrestris/shogun-util/pull/63) introduced parameter for controlling the `TRANSPARENT` mode of a layer is now expected in here.

@terrestris/devs  please review