### PR TITLE
Set layer entity configuration on ol layer instance as layerConfig

### DIFF
--- a/src/parser/SHOGunApplicationUtil.spec.ts
+++ b/src/parser/SHOGunApplicationUtil.spec.ts
@@ -176,6 +176,7 @@ describe('SHOGunApplicationUtil', () => {
     expected.set('propertyConfig', myLayer.clientConfig?.propertyConfig);
     expected.set('legendUrl', myLayer.sourceConfig.legendUrl);
     expected.set('hoverable', myLayer.clientConfig?.hoverable);
+    expected.set('layerConfig', myLayer);
 
     expect(JSON.stringify(layer)).toEqual(JSON.stringify(expected));
   });
@@ -242,6 +243,7 @@ describe('SHOGunApplicationUtil', () => {
     expected.set('propertyConfig', myLayer.clientConfig?.propertyConfig);
     expected.set('legendUrl', myLayer.sourceConfig.legendUrl);
     expected.set('hoverable', myLayer.clientConfig?.hoverable);
+    expected.set('layerConfig', myLayer);
 
     expect(JSON.stringify(layer)).toEqual(JSON.stringify(expected));
   });
@@ -282,6 +284,7 @@ describe('SHOGunApplicationUtil', () => {
     expected.set('propertyConfig', myLayer.clientConfig?.propertyConfig);
     expected.set('legendUrl', myLayer.sourceConfig.legendUrl);
     expected.set('hoverable', myLayer.clientConfig?.hoverable);
+    expected.set('layerConfig', myLayer);
 
     // @ts-ignore
     // eslint-disable-next-line camelcase


### PR DESCRIPTION
This PR suggests to set the original layer configuration as property `layerConfig` while parsing of OpenLayers layer instances.

This might be useful for the case, if we need to create a clone of the existing layer later (e.g. to reuse it in a overview map). This way, we can simply parse the configuration again with `parseLayer` method.

Also enhances typing and adds some null checks.

Please review @terrestris/devs 