### PR TITLE
Bearer Token Header to be optional

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -15,6 +15,7 @@ export interface DefaultLayerSourceConfig {
   resolutions?: number[];
   attribution?: string;
   requestParams?: DefaultRequestParams;
+  bearerToken?: boolean;
 }
 
 export interface DefaultLayerPropertyConfig {

--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -15,7 +15,7 @@ export interface DefaultLayerSourceConfig {
   resolutions?: number[];
   attribution?: string;
   requestParams?: DefaultRequestParams;
-  bearerToken?: boolean;
+  useBearerToken?: boolean;
 }
 
 export interface DefaultLayerPropertyConfig {

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -202,6 +202,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
+      bearerToken,
       requestParams = {'TRANSPARENT': true}
     } = layer.sourceConfig || {};
 
@@ -219,7 +220,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         ...requestParams
       },
       crossOrigin,
-      imageLoadFunction: this.bearerTokenLoadFunction.bind(this)
+      imageLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, bearerToken)
     });
 
     const imageLayer = new OlImageLayer({
@@ -238,6 +239,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
+      bearerToken,
       tileSize = 256,
       tileOrigin,
       resolutions,
@@ -269,7 +271,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         ...requestParams
       },
       crossOrigin,
-      tileLoadFunction: this.bearerTokenLoadFunction.bind(this)
+      tileLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, bearerToken)
     });
 
     const tileLayer = new OlTileLayer({
@@ -343,7 +345,8 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     const {
       attribution,
       url,
-      layerNames
+      layerNames,
+      bearerToken
     } = layer.sourceConfig || {};
 
     const {
@@ -365,7 +368,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
           projection,
           success,
           failure
-        });
+        }, bearerToken);
       }
     });
 
@@ -407,7 +410,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     projection: OlProjectionLike;
     success?: (features: OlFeature<OlGeometry>[]) => void;
     failure?: () => void;
-  }) {
+  }, bearerToken: boolean = true) {
     try {
       const params = UrlUtil.objectToRequestString({
         SERVICE: 'WFS',
@@ -422,9 +425,9 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       const wfsUrl = `${opts.url}${opts.url.endsWith('?') ? '' : '?'}${params}`;
 
       const response = await fetch(wfsUrl, {
-        headers: {
+        headers: bearerToken ? {
           ...getBearerTokenHeader(this.client?.getKeycloak())
-        }
+        } : {}
       });
 
       if (!response.ok) {
@@ -448,12 +451,12 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     }
   }
 
-  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string) {
+  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string, bearerToken: boolean = true) {
     try {
       const response = await fetch(src, {
-        headers: {
+        headers: bearerToken ? {
           ...getBearerTokenHeader(this.client?.getKeycloak())
-        }
+        } : {}
       });
 
       const imageElement = (imageTile as OlImageTile).getImage() as HTMLImageElement;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -202,7 +202,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
-      bearerToken,
+      useBearerToken,
       requestParams = {'TRANSPARENT': true}
     } = layer.sourceConfig || {};
 
@@ -220,7 +220,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         ...requestParams
       },
       crossOrigin,
-      imageLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, bearerToken)
+      imageLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, useBearerToken)
     });
 
     const imageLayer = new OlImageLayer({
@@ -239,7 +239,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
-      bearerToken,
+      useBearerToken,
       tileSize = 256,
       tileOrigin,
       resolutions,
@@ -271,7 +271,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         ...requestParams
       },
       crossOrigin,
-      tileLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, bearerToken)
+      tileLoadFunction: (imageTile, src) => this.bearerTokenLoadFunction(imageTile, src, useBearerToken)
     });
 
     const tileLayer = new OlTileLayer({
@@ -346,7 +346,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       attribution,
       url,
       layerNames,
-      bearerToken
+      useBearerToken
     } = layer.sourceConfig || {};
 
     const {
@@ -368,7 +368,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
           projection,
           success,
           failure
-        }, bearerToken);
+        }, useBearerToken);
       }
     });
 
@@ -410,7 +410,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     projection: OlProjectionLike;
     success?: (features: OlFeature<OlGeometry>[]) => void;
     failure?: () => void;
-  }, bearerToken: boolean = false) {
+  }, useBearerToken: boolean = false) {
     try {
       const params = UrlUtil.objectToRequestString({
         SERVICE: 'WFS',
@@ -425,7 +425,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       const wfsUrl = `${opts.url}${opts.url.endsWith('?') ? '' : '?'}${params}`;
 
       const response = await fetch(wfsUrl, {
-        headers: bearerToken ? {
+        headers: useBearerToken ? {
           ...getBearerTokenHeader(this.client?.getKeycloak())
         } : {}
       });
@@ -451,10 +451,10 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     }
   }
 
-  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string, bearerToken: boolean = false) {
+  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string, useBearerToken: boolean = false) {
     try {
       const response = await fetch(src, {
-        headers: bearerToken ? {
+        headers: useBearerToken ? {
           ...getBearerTokenHeader(this.client?.getKeycloak())
         } : {}
       });

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -410,7 +410,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     projection: OlProjectionLike;
     success?: (features: OlFeature<OlGeometry>[]) => void;
     failure?: () => void;
-  }, bearerToken: boolean = true) {
+  }, bearerToken: boolean = false) {
     try {
       const params = UrlUtil.objectToRequestString({
         SERVICE: 'WFS',
@@ -451,7 +451,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     }
   }
 
-  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string, bearerToken: boolean = true) {
+  private async bearerTokenLoadFunction(imageTile: OlTile | OlImage, src: string, bearerToken: boolean = false) {
     try {
       const response = await fetch(src, {
         headers: bearerToken ? {


### PR DESCRIPTION
Bearer token header can now be set or unset with the layer config. 
By default it is always sent

Please review @terrestris/devs 