### PR TITLE
Set useBearerToken as property of the layer

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -399,6 +399,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     olLayer.set('propertyConfig', layer.clientConfig?.propertyConfig);
     olLayer.set('legendUrl', layer.sourceConfig.legendUrl);
     olLayer.set('hoverable', layer.clientConfig?.hoverable);
+    olLayer.set('useBearerToken', layer.sourceConfig?.useBearerToken);
   }
 
   private async bearerTokenLoadFunctionVector(opts: {


### PR DESCRIPTION
This is might be useful if the token should be used/ignored in other components as well.

Please review @terrestris/devs.