### PR TITLE
Provide matrixSet name and compute matrix sizes

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -14,6 +14,7 @@ export interface DefaultLayerSourceConfig {
   tileOrigin?: [number, number];
   resolutions?: number[];
   attribution?: string;
+  matrixSet?: string;
   requestParams?: DefaultRequestParams;
   useBearerToken?: boolean;
 }


### PR DESCRIPTION
Be more specific while parsing of WMTS layers: 

* Optionally provide `matrixSet` parameter, which is required if there is more than one matrix set defined in the layer capabilities. 
* Manually compute matrix sizes
  * In most cases the matrix dimensions are computed based `Math.pow(2, x)`  formula, where x points to the current zoom level
  * An example for customized sizes: (e.g. [WMTS TopPlusOpen](https://sg.geodatenzentrum.de/wmts_topplus_open/1.0.0/WMTSCapabilities.xml?SERVICE=WMTS&REQUEST=GetCapabilities&VERSION=1.3.0) (MatrixSet `EU_EPSG_25832_TOPPLUS`)
  
Additionally set `matrixSizes` propetry on WMTS source to make it accessible for[ mapfish-print-manager](https://github.com/terrestris/mapfish-print-manager/blob/master/src/serializer/MapFishPrintV3WMTSSerializer.js#L67) and ensure, that the WMTS layer will be processed properly while extracting print output.

Please review @terrestris/devs 
