### PR TITLE
Bump ol-util to v7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
-        "@terrestris/ol-util": "^6.0.1",
+        "@terrestris/ol-util": "^7.3.0",
         "geojson": "^0.5.0",
         "keycloak-js": "^19.0.1",
         "lodash": "^4.17.21",
@@ -3150,17 +3150,19 @@
       }
     },
     "node_modules/@terrestris/ol-util": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
-      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-7.3.0.tgz",
+      "integrity": "sha512-UkK8BxMl8CAoeewM0N8KC/DsnrOfaZdfo5CARWZe37tBCgBL7x4GLRPrU57dDPSIHV4ruqddQP5IHemHfDiLVA==",
       "dependencies": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
+        "@types/geojson": "^7946.0.8",
+        "geostyler-openlayers-parser": "^3.1.0",
         "lodash": "^4.17.21",
-        "polygon-splitter": "^0.0.7",
-        "proj4": "^2.7.5",
+        "polygon-splitter": "^0.0.11",
+        "proj4": "^2.8.0",
         "shpjs": "^4.0.2",
-        "typescript": "^4.5.5"
+        "typescript": "^4.7.4"
       },
       "engines": {
         "node": ">=14",
@@ -4811,8 +4813,7 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-      "dev": true
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -5706,8 +5707,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5999,8 +5999,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -7318,8 +7317,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -7399,6 +7397,28 @@
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
       "dependencies": {
         "quickselect": "^2.0.0"
+      }
+    },
+    "node_modules/geostyler-openlayers-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.2.0.tgz",
+      "integrity": "sha512-eHuuAwMooGmoYyf3Ehc2yX/SPWexxM21HbbToEcen4Dpj04UJ6BjZk0l2YEb+Uc9qpUhn2C0UvjBMLQaDtM3QA==",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "geostyler-style": "^6.0.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "ol": "^6.0.0"
+      }
+    },
+    "node_modules/geostyler-style": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-6.0.0.tgz",
+      "integrity": "sha512-dCMwzoPdkFwBlS0d6xw6MkAdT+mhCEk44I5rLVlGxcr4wDNCCgoe2SQt3Qm7fFfb57KzMZYFPJnwBBSHIrSN7A==",
+      "dependencies": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/geotiff": {
@@ -7909,7 +7929,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12265,7 +12284,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -12644,6 +12662,11 @@
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.1.0.tgz",
+      "integrity": "sha512-3hTIM2j/v9Lio+wOyur3kckD4NxruZhpowUbEgmyikW+a2Kppjtu1eN+AhnMQtoHW46zld88JiYWv6fxpsDrTQ=="
+    },
     "node_modules/polygon-clipping": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.3.tgz",
@@ -12653,11 +12676,51 @@
       }
     },
     "node_modules/polygon-splitter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.7.tgz",
-      "integrity": "sha512-YSXN/PAfrD3+KPfqIY1J2QgA7FJLycRI7f7t21IdkfJ8taQU1fFmORzb0ZuAWfHRf/u4r66po0rWNpNjZUw+Yw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.11.tgz",
+      "integrity": "sha512-g+uion0orbjfbOew3hYXHfevLQyedR8BgsAX9Hq+ztFj4hXLwTOK92AfgOdzteJEmDojVShvsCMHQdLPc7kW/A==",
       "dependencies": {
+        "@turf/rewind": "^6.5.0",
+        "glob": "^8.0.3",
+        "point-in-polygon-hao": "^1.1.0",
         "robust-predicates": "^2.0.4"
+      }
+    },
+    "node_modules/polygon-splitter/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/polygon-splitter/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/polygon-splitter/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -14547,8 +14610,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.1",
@@ -16985,17 +17047,19 @@
       }
     },
     "@terrestris/ol-util": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-6.0.1.tgz",
-      "integrity": "sha512-8AH+1IX2Mmg5wckKjaxgRFayq3RhJ6L15pVRd4qlF9nKPwnDj2ysPJY3aJA9BwsJ5I6cue/TTyPqjU3u2nGyRA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/ol-util/-/ol-util-7.3.0.tgz",
+      "integrity": "sha512-UkK8BxMl8CAoeewM0N8KC/DsnrOfaZdfo5CARWZe37tBCgBL7x4GLRPrU57dDPSIHV4ruqddQP5IHemHfDiLVA==",
       "requires": {
         "@terrestris/base-util": "^1.0.1",
         "@turf/turf": "^6.5.0",
+        "@types/geojson": "^7946.0.8",
+        "geostyler-openlayers-parser": "^3.1.0",
         "lodash": "^4.17.21",
-        "polygon-splitter": "^0.0.7",
-        "proj4": "^2.7.5",
+        "polygon-splitter": "^0.0.11",
+        "proj4": "^2.8.0",
         "shpjs": "^4.0.2",
-        "typescript": "^4.5.5"
+        "typescript": "^4.7.4"
       }
     },
     "@tootallnate/once": {
@@ -18315,8 +18379,7 @@
     "@types/geojson": {
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-      "dev": true
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -18980,8 +19043,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -19187,8 +19249,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -20192,8 +20253,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -20262,6 +20322,25 @@
             "quickselect": "^2.0.0"
           }
         }
+      }
+    },
+    "geostyler-openlayers-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.2.0.tgz",
+      "integrity": "sha512-eHuuAwMooGmoYyf3Ehc2yX/SPWexxM21HbbToEcen4Dpj04UJ6BjZk0l2YEb+Uc9qpUhn2C0UvjBMLQaDtM3QA==",
+      "requires": {
+        "color-name": "^1.1.4",
+        "geostyler-style": "^6.0.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "geostyler-style": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/geostyler-style/-/geostyler-style-6.0.0.tgz",
+      "integrity": "sha512-dCMwzoPdkFwBlS0d6xw6MkAdT+mhCEk44I5rLVlGxcr4wDNCCgoe2SQt3Qm7fFfb57KzMZYFPJnwBBSHIrSN7A==",
+      "requires": {
+        "@types/lodash": "^4.14.168",
+        "lodash": "^4.17.21"
       }
     },
     "geotiff": {
@@ -20622,7 +20701,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -23803,7 +23881,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -24082,6 +24159,11 @@
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
     },
+    "point-in-polygon-hao": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.1.0.tgz",
+      "integrity": "sha512-3hTIM2j/v9Lio+wOyur3kckD4NxruZhpowUbEgmyikW+a2Kppjtu1eN+AhnMQtoHW46zld88JiYWv6fxpsDrTQ=="
+    },
     "polygon-clipping": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.3.tgz",
@@ -24091,11 +24173,44 @@
       }
     },
     "polygon-splitter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.7.tgz",
-      "integrity": "sha512-YSXN/PAfrD3+KPfqIY1J2QgA7FJLycRI7f7t21IdkfJ8taQU1fFmORzb0ZuAWfHRf/u4r66po0rWNpNjZUw+Yw==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/polygon-splitter/-/polygon-splitter-0.0.11.tgz",
+      "integrity": "sha512-g+uion0orbjfbOew3hYXHfevLQyedR8BgsAX9Hq+ztFj4hXLwTOK92AfgOdzteJEmDojVShvsCMHQdLPc7kW/A==",
       "requires": {
+        "@turf/rewind": "^6.5.0",
+        "glob": "^8.0.3",
+        "point-in-polygon-hao": "^1.1.0",
         "robust-predicates": "^2.0.4"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "prelude-ls": {
@@ -25543,8 +25658,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@terrestris/base-util": "^1.0.1",
-    "@terrestris/ol-util": "^6.0.1",
+    "@terrestris/ol-util": "^7.3.0",
     "geojson": "^0.5.0",
     "keycloak-js": "^19.0.1",
     "lodash": "^4.17.21",

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -27,7 +27,7 @@ import { bbox as olStrategyBbox } from 'ol/loadingstrategy';
 import { UrlUtil } from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
 import Logger from '@terrestris/base-util/dist/Logger';
 
-import ProjectionUtil from '@terrestris/ol-util/dist/ProjectionUtil/ProjectionUtil';
+import ProjectionUtil, { defaultProj4CrsDefinitions } from '@terrestris/ol-util/dist/ProjectionUtil/ProjectionUtil';
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
 
 import Application, { DefaultLayerTree } from '../model/Application';
@@ -55,8 +55,8 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
   }
 
   async parseMapView(application: T, additionalOpts?: OlViewOptions): Promise<OlView> {
-    // TODO Should this be called here?
-    ProjectionUtil.initProj4Definitions(null);
+
+    ProjectionUtil.initProj4Definitions(defaultProj4CrsDefinitions, false);
 
     const mapView = application.clientConfig?.mapView;
 


### PR DESCRIPTION
* Bumps ol-util to v7.3.0
* Fixes initialization of the default proj4 definitions

Replaces https://github.com/terrestris/shogun-util/pull/97

Please review @terrestris/devs 