### PR TITLE
Apply application specific layer configs

### DIFF
--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -17,6 +17,7 @@ export interface DefaultApplicationToolConfig {
 }
 
 export interface DefaultApplicationLayerConfig {
+  layerId: number;
   clientConfig?: DefaultLayerClientConfig;
   sourceConfig?: DefaultLayerSourceConfig;
 }

--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -47,7 +47,7 @@ export interface ApplicationArgs extends BaseEntityArgs {
   stateOnly?: boolean;
   clientConfig?: DefaultApplicationClientConfig;
   layerTree?: DefaultLayerTree;
-  layerConfig?: DefaultApplicationLayerConfig;
+  layerConfig?: DefaultApplicationLayerConfig[];
   toolConfig?: DefaultApplicationToolConfig[];
 }
 
@@ -56,7 +56,7 @@ export default class Application extends BaseEntity {
   stateOnly?: boolean;
   clientConfig?: DefaultApplicationClientConfig;
   layerTree?: DefaultLayerTree;
-  layerConfig?: DefaultApplicationLayerConfig;
+  layerConfig?: DefaultApplicationLayerConfig[];
   toolConfig?: DefaultApplicationToolConfig[];
 
   constructor({


### PR DESCRIPTION
This adds support for application specific layer configurations, e.g. to make a layer hoverable/queryable in a specific application even if it is disabled by default.

Requires [!569](https://github.com/terrestris/shogun/pull/569).

Please review @terrestris/devs.