### PR TITLE
feat: add downloadConfig to layer

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -27,7 +27,7 @@ export interface DefaultLayerPropertyConfig {
 
 export interface DownloadConfig {
   downloadUrl: string;
-  formatName: string;
+  formatName?: string;
 }
 
 export interface DefaultLayerClientConfig {

--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -25,6 +25,11 @@ export interface DefaultLayerPropertyConfig {
   visible?: boolean;
 }
 
+export interface DownloadConfig {
+  downloadUrl: string;
+  formatName: string;
+}
+
 export interface DefaultLayerClientConfig {
   minResolution?: number;
   maxResolution?: number;
@@ -33,6 +38,7 @@ export interface DefaultLayerClientConfig {
   propertyConfig?: DefaultLayerPropertyConfig[];
   crossOrigin?: string;
   opacity?: number;
+  downloadConfig?: DownloadConfig[];
 }
 
 export interface LayerArgs extends BaseEntityArgs {

--- a/src/parser/SHOGunApplicationUtil.spec.ts
+++ b/src/parser/SHOGunApplicationUtil.spec.ts
@@ -135,6 +135,10 @@ describe('SHOGunApplicationUtil', () => {
           displayName: 'id',
           visible: true
         }],
+        downloadConfig: [{
+          downloadUrl: 'https://example.com/geo/ows?request=GetFeature&outputFormat=application%2Fjson',
+          formatName: 'GeoJSON'
+        }],
         searchable: true
       },
       sourceConfig: {
@@ -174,6 +178,7 @@ describe('SHOGunApplicationUtil', () => {
     expected.set('type', myLayer.type);
     expected.set('searchable', myLayer.clientConfig?.searchable);
     expected.set('propertyConfig', myLayer.clientConfig?.propertyConfig);
+    expected.set('downloadConfig', myLayer.clientConfig?.downloadConfig);
     expected.set('legendUrl', myLayer.sourceConfig.legendUrl);
     expected.set('hoverable', myLayer.clientConfig?.hoverable);
 

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -473,6 +473,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     olLayer.set('type', layer.type);
     olLayer.set('searchable', layer.clientConfig?.searchable);
     olLayer.set('propertyConfig', layer.clientConfig?.propertyConfig);
+    olLayer.set('downloadConfig', layer.clientConfig?.downloadConfig);
     olLayer.set('legendUrl', layer.sourceConfig.legendUrl);
     olLayer.set('hoverable', layer.clientConfig?.hoverable);
     olLayer.set('useBearerToken', layer.sourceConfig?.useBearerToken);


### PR DESCRIPTION
Allows to save download related configuration in layer.clientConfig, e.g.:

```json
{
  "hoverable": false,
  "downloadConfig": [
    {
      "downloadUrl": "https://localhost/geoserver/SHOGUN/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=SHOGUN%3APEGEL&maxFeatures=50&outputFormat=SHAPE-ZIP",
      "formatName": "Shapefile"
    },
    {
      "downloadUrl": "https://localhost/geoserver/SHOGUN/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=SHOGUN%3APEGEL&maxFeatures=50&outputFormat=application%2Fjson",
      "formatName": "GeoJSON"
    }
  ]
}
``` 

@terrestris/devs Please review