### PR TITLE
fix: remove no-cors mode, otherwise authentication token won't be sent

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -597,7 +597,6 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         URL.revokeObjectURL(this.objectUrls[src]);
       }
       const response = await fetch(src, {
-        mode: 'no-cors',
         headers: useBearerToken ? {
           ...getBearerTokenHeader(this.client?.getKeycloak())
         } : {}


### PR DESCRIPTION
Reverts parts of https://github.com/terrestris/shogun-util/pull/220.

With `no-cors` mode the auth bearer token will be ignored.

Please review @terrestris/devs 