### PR TITLE
Set legendUrl for WMTS layers

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -407,8 +407,6 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       }
     });
 
-    source.set('legendUrl', legendUrl);
-
     const wmtsLayer = new OlTileLayer({
       source,
       minResolution,
@@ -417,6 +415,8 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     });
 
     this.setLayerProperties(wmtsLayer, layer);
+
+    wmtsLayer.set('legendUrl', legendUrl);
 
     return wmtsLayer;
   }

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -396,6 +396,19 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
 
     source.set('matrixSizes', matrixSizes);
 
+    let legendUrl = '';
+    capabilities.Contents?.Layer?.forEach((l: any) => {
+      if (l.Identifier === layerNames) {
+        l.Style?.forEach((s: any) => {
+          if (s.LegendURL) {
+            legendUrl = s.LegendURL[0].href;
+          }
+        });
+      }
+    });
+
+    source.set('legendUrl', legendUrl);
+
     const wmtsLayer = new OlTileLayer({
       source,
       minResolution,


### PR DESCRIPTION
Sets the `legendUrl` property on a WMTS layer if its provided in the capabilities document.

@terrestris/devs please review