### PR TITLE
Sets legend url on source for wmts

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -407,6 +407,8 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       }
     });
 
+    source.set('legendUrl', legendUrl);
+
     const wmtsLayer = new OlTileLayer({
       source,
       minResolution,
@@ -415,8 +417,6 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     });
 
     this.setLayerProperties(wmtsLayer, layer);
-
-    wmtsLayer.set('legendUrl', legendUrl);
 
     return wmtsLayer;
   }


### PR DESCRIPTION
This MR fixes https://github.com/terrestris/shogun-util/pull/224#pullrequestreview-1211783974 and sets the `legendUrl` at the source. In a previous version a manually configured (in shogun-admin) `legendUrl` wasn't considered when the value was set at the layer. In the following step, the values are bounded to the layer by [`setLayerProperties`](https://github.com/terrestris/shogun-util/blob/83312339f65a5fe0b1d78e2afe49a6c905beb662/src/parser/SHOGunApplicationUtil.ts#L550), including the `legendUrl` stored at `sourceConfig`.

@terrestris/devs please review