### PR TITLE
feat: register possibly configured additional crs definitions on client

### DIFF
--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -1,3 +1,4 @@
+import { CrsDefinition } from '@terrestris/ol-util/dist/ProjectionUtil/ProjectionUtil';
 import BaseEntity, { BaseEntityArgs } from './BaseEntity';
 import {
   DefaultLayerClientConfig,
@@ -35,6 +36,7 @@ export interface DefaultMapView {
   extent?: [number, number, number, number];
   projection?: string;
   resolutions?: number[];
+  crsDefinitions?: CrsDefinition[];
 }
 export interface DefaultLegalConfig {
   contact?: string;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -39,6 +39,8 @@ import SHOGunAPIClient from '../service/SHOGunAPIClient';
 
 import { getBearerTokenHeader } from '../security/getBearerTokenHeader';
 
+import _uniqueBy from 'lodash/uniqBy';
+
 import {
   allLayersByIds
 } from '../graphqlqueries/Layers';
@@ -60,7 +62,14 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
 
   async parseMapView(application: T, additionalOpts?: OlViewOptions): Promise<OlView> {
 
-    ProjectionUtil.initProj4Definitions(defaultProj4CrsDefinitions, false);
+    const customProj4Definitions = application.clientConfig?.mapView?.crsDefinitions || [];
+
+    const proj4Definitions = [
+      ...customProj4Definitions,
+      ...defaultProj4CrsDefinitions
+    ];
+
+    ProjectionUtil.initProj4Definitions(_uniqueBy(proj4Definitions, 'crsCode'), false);
 
     const mapView = application.clientConfig?.mapView;
 


### PR DESCRIPTION
Register additional CRS definitions on GIS client, if configured.

See also https://github.com/terrestris/shogun/pull/670

Please review @terrestris/devs 