### PR TITLE
feat: add defaultLangauge type to clientconfig

### DIFF
--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -49,6 +49,7 @@ export interface DefaultApplicationClientConfig {
   description?: string;
   legal?: DefaultLegalConfig;
   theme?: DefaultApplicationTheme;
+  defaultLanguage?: string;
 }
 
 export interface ApplicationArgs extends BaseEntityArgs {


### PR DESCRIPTION
See title, possible use case: An application shall always have a default language that is not the browser detected language.

Validation: iso language codes are accepted (`de`, `pl` etc.). Might be added ?

@terrestris/devs 