### PR TITLE
Introduce GenericService as abstract base service 

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -114,7 +114,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       try {
         const {
           allLayersByIds: layers
-        } = await this.client.graphql().sendQuery<S>({
+        } = await this.client.graphql().sendQuery<S[]>({
           query: allLayersByIds,
           variables: {
             ids: layerIds

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -17,10 +17,7 @@ import OlImageLayer from 'ol/layer/Image';
 import OlTileLayer from 'ol/layer/Tile';
 import OlLayerVector from 'ol/layer/Vector';
 import { bbox as olStrategyBbox } from 'ol/loadingstrategy';
-import {
-  fromLonLat,
-  ProjectionLike as OlProjectionLike
-} from 'ol/proj';
+import { fromLonLat, ProjectionLike as OlProjectionLike } from 'ol/proj';
 import { Units } from 'ol/proj/Units';
 import OlImageWMS from 'ol/source/ImageWMS';
 import OlTileWMS from 'ol/source/TileWMS';
@@ -45,9 +42,9 @@ export interface SHOGunApplicationUtilOpts {
 
 class SHOGunApplicationUtil<T extends Application, S extends Layer> {
 
-  private client: SHOGunAPIClient | undefined;
+  private readonly client: SHOGunAPIClient | undefined;
 
-  private objectUrls: any = {};
+  private readonly objectUrls: any = {};
 
   constructor(opts?: SHOGunApplicationUtilOpts) {
     // TODO Default client?
@@ -88,7 +85,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       ];
     }
 
-    const view = new OlView({
+    return new OlView({
       projection,
       center,
       zoom,
@@ -96,8 +93,6 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       resolutions,
       ...additionalOpts
     });
-
-    return view;
   }
 
   async parseLayerTree(application: T, projection?: OlProjectionLike, keepClientConfig = false) {
@@ -131,11 +126,10 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
         if (layerTree.children) {
           const nodes = await this.parseNodes(layerTree.children, layers, projection, keepClientConfig);
 
-          const tree = new OlLayerGroup({
+          return new OlLayerGroup({
             layers: nodes.reverse(),
             visible: layerTree.checked
           });
-          return tree;
         }
       } catch (e) {
         Logger.warn('Could not parse the layer tree: ' + e);

--- a/src/service/AppInfoService/index.ts
+++ b/src/service/AppInfoService/index.ts
@@ -1,24 +1,15 @@
-import Keycloak from 'keycloak-js';
-
 import { AppInfo } from '../../model/AppInfo';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
-export interface AppInfoServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type AppInfoServiceOpts = GenericServiceOpts;
 
-export class AppInfoService {
-
-  private basePath: string;
-
-  private keycloak?: Keycloak;
+export class AppInfoService extends GenericService {
 
   constructor(opts: AppInfoServiceOpts = {
     basePath: '/info'
   }) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
   async getAppInfo(fetchOpts?: RequestInit): Promise<AppInfo> {
@@ -35,9 +26,7 @@ export class AppInfoService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the application info: ${error}`);
     }

--- a/src/service/ApplicationService/index.spec.ts
+++ b/src/service/ApplicationService/index.spec.ts
@@ -1,5 +1,5 @@
 import Application from '../../model/Application';
-import GenericService from '../GenericService';
+import GenericEntityService from '../GenericEntityService';
 import ApplicationService from '.';
 
 describe('ApplicationService', () => {
@@ -14,11 +14,11 @@ describe('ApplicationService', () => {
   });
 
   it('extends the GenericService', () => {
-    expect(service instanceof GenericService).toBeTruthy();
+    expect(service instanceof GenericEntityService).toBeTruthy();
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/applications');
+    expect(service.getBasePath()).toEqual('/applications');
   });
 
 });

--- a/src/service/ApplicationService/index.ts
+++ b/src/service/ApplicationService/index.ts
@@ -1,9 +1,9 @@
 import Application from '../../model/Application';
-import GenericService, { GenericServiceOpts } from '../GenericService';
+import GenericEntityService, { GenericEntityServiceOpts } from '../GenericEntityService';
 
-export class ApplicationService<T extends Application> extends GenericService<T> {
+export class ApplicationService<T extends Application> extends GenericEntityService<T> {
 
-  constructor(opts: GenericServiceOpts = {
+  constructor(opts: GenericEntityServiceOpts = {
     basePath: '/applications'
   }) {
     super(opts);

--- a/src/service/AuthService/index.ts
+++ b/src/service/AuthService/index.ts
@@ -1,24 +1,15 @@
-import Keycloak from 'keycloak-js';
-
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
-export interface AuthServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type AuthServiceOpts = GenericServiceOpts;
 
-export class AuthService {
-
-  private basePath: string;
-
-  private keycloak?: Keycloak;
+export class AuthService extends GenericService {
 
   constructor(opts: AuthServiceOpts = {
     basePath: '/sso'
   }) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
   async logout(requestOpts?: RequestInit): Promise<void> {

--- a/src/service/CacheService/index.ts
+++ b/src/service/CacheService/index.ts
@@ -1,24 +1,15 @@
-import Keycloak from 'keycloak-js';
-
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
-export interface CacheServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type CacheServiceOpts = GenericServiceOpts;
 
-export class CacheService {
-
-  private basePath: string;
-
-  private keycloak?: Keycloak;
+export class CacheService extends GenericService {
 
   constructor(opts: CacheServiceOpts = {
     basePath: '/cache'
   }) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
   async evictCache(fetchOpts?: RequestInit): Promise<void> {

--- a/src/service/FileService/index.spec.ts
+++ b/src/service/FileService/index.spec.ts
@@ -18,7 +18,7 @@ describe('FileService', () => {
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/files');
+    expect(service.getBasePath()).toEqual('/files');
   });
 
 });

--- a/src/service/GenericEntityService/index.spec.ts
+++ b/src/service/GenericEntityService/index.spec.ts
@@ -1,6 +1,6 @@
 import BaseEntity, { BaseEntityArgs } from '../../model/BaseEntity';
 import fetchSpy, { failureResponse, successResponse } from '../../spec/fetchSpy';
-import GenericService, { GenericServiceOpts } from '.';
+import GenericService, { GenericEntityServiceOpts } from '.';
 
 interface DummyEntityArgs extends BaseEntityArgs {
   dummyField?: string;
@@ -22,7 +22,7 @@ class DummyEntity extends BaseEntity {
 }
 
 class DummyService extends GenericService<DummyEntity> {
-  constructor(opts: GenericServiceOpts = {
+  constructor(opts: GenericEntityServiceOpts = {
     basePath: '/dummy'
   }) {
     super(opts);

--- a/src/service/GenericEntityService/index.ts
+++ b/src/service/GenericEntityService/index.ts
@@ -1,0 +1,154 @@
+import BaseEntity from '../../model/BaseEntity';
+import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
+import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericServiceOpts } from '../GenericService';
+import PermissionService from '../PermissionService';
+
+export type GenericEntityServiceOpts = GenericServiceOpts;
+
+export abstract class GenericEntityService<T extends BaseEntity> extends PermissionService {
+
+  constructor(opts: GenericEntityServiceOpts) {
+    super(opts);
+  }
+
+  async findAll(fetchOpts?: RequestInit): Promise<T[]> {
+    try {
+      const response = await fetch(this.basePath, {
+        method: 'GET',
+        headers: {
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+
+      const json = await response.json();
+
+      return json.content;
+    } catch (error) {
+      throw new Error(`Error while requesting all entities: ${error}`);
+    }
+  }
+
+  async findOne(id: string | number, fetchOpts?: RequestInit): Promise<T> {
+    try {
+      const response = await fetch(`${this.basePath}/${id}`, {
+        method: 'GET',
+        headers: {
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+
+      const json: T = await response.json();
+
+      return json;
+    } catch (error) {
+      throw new Error(`Error while requesting a single entity: ${error}`);
+    }
+  }
+
+  async add(t: T, fetchOpts?: RequestInit): Promise<T> {
+    try {
+      const response = await fetch(this.basePath, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getCsrfTokenHeader(),
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        body: JSON.stringify(t),
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+
+      const json: T = await response.json();
+
+      return json;
+    } catch (error) {
+      throw new Error(`Error while creating an entity: ${error}`);
+    }
+  }
+
+  async update(t: T, fetchOpts?: RequestInit): Promise<T> {
+    try {
+      const response = await fetch(`${this.basePath}/${t.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getCsrfTokenHeader(),
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        body: JSON.stringify(t),
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      throw new Error(`Error while updating an entity: ${error}`);
+    }
+  }
+
+  async updatePartial(t: Partial<T>, fetchOpts?: RequestInit): Promise<T> {
+    try {
+      const response = await fetch(`${this.basePath}/${t.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getCsrfTokenHeader(),
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        body: JSON.stringify(t),
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      throw new Error(`Error while updating an entity partially: ${error}`);
+    }
+  }
+
+  async delete(id: string | number, fetchOpts?: RequestInit): Promise<void> {
+    try {
+      const response = await fetch(`${this.basePath}/${id}`, {
+        method: 'DELETE',
+        headers: {
+          ...getBearerTokenHeader(this.keycloak)
+        },
+        ...fetchOpts
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error status: ${response.status}`);
+      }
+    } catch (error) {
+      throw new Error(`Error while deleting an entity: ${error}`);
+    }
+  }
+
+  getBasePath(): string {
+    return this.basePath;
+  }
+
+}
+
+export default GenericEntityService;

--- a/src/service/GenericFileService/index.ts
+++ b/src/service/GenericFileService/index.ts
@@ -1,23 +1,14 @@
-import Keycloak from 'keycloak-js';
-
 import SHOGunFile from '../../model/File';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
-export interface GenericFileServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type GenericFileServiceOpts = GenericServiceOpts;
 
-export abstract class GenericFileService<T extends SHOGunFile> {
+export abstract class GenericFileService<T extends SHOGunFile> extends GenericService {
 
-  basePath: string;
-
-  keycloak?: Keycloak;
-
-  constructor(opts: GenericFileServiceOpts) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+  protected constructor(opts: GenericFileServiceOpts) {
+    super(opts);
   }
 
   async findAll(fetchOpts?: RequestInit): Promise<T[]> {
@@ -34,9 +25,7 @@ export abstract class GenericFileService<T extends SHOGunFile> {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: T[] = await response.json();
-
-      return json ;
+      return await response.json() ;
     } catch (error) {
       throw new Error(`Error while requesting all entities: ${error}`);
     }
@@ -56,9 +45,7 @@ export abstract class GenericFileService<T extends SHOGunFile> {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const blob: Blob = await response.blob();
-
-      return blob;
+      return await response.blob();
     } catch (error) {
       throw new Error(`Error while requesting a single entity: ${error}`);
     }
@@ -84,9 +71,7 @@ export abstract class GenericFileService<T extends SHOGunFile> {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: T = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while creating an entity: ${error}`);
     }
@@ -108,6 +93,10 @@ export abstract class GenericFileService<T extends SHOGunFile> {
     } catch (error) {
       throw new Error(`Error while deleting an entity: ${error}`);
     }
+  }
+
+  getBasePath() {
+    return this.basePath;
   }
 
 }

--- a/src/service/GenericService/index.ts
+++ b/src/service/GenericService/index.ts
@@ -1,166 +1,18 @@
 import Keycloak from 'keycloak-js';
 
-import BaseEntity from '../../model/BaseEntity';
-import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
-import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
-import PermissionService from '../PermissionService';
-
-export interface GenericServiceOpts {
+export type GenericServiceOpts = {
   basePath: string;
   keycloak?: Keycloak;
-}
+};
 
-export abstract class GenericService<T extends BaseEntity> extends PermissionService {
+export abstract class GenericService {
 
-  basePath: string;
+  protected readonly basePath: string;
+  protected readonly keycloak?: Keycloak;
 
-  keycloak?: Keycloak;
-
-  constructor(opts: GenericServiceOpts) {
-    super({
-      basePath: opts.basePath,
-      keycloak: opts.keycloak
-    });
-
+  protected constructor(opts: GenericServiceOpts) {
     this.basePath = opts.basePath;
     this.keycloak = opts.keycloak;
-  }
-
-  async findAll(fetchOpts?: RequestInit): Promise<T[]> {
-    try {
-      const response = await fetch(this.basePath, {
-        method: 'GET',
-        headers: {
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-
-      const json = await response.json();
-
-      return json.content;
-    } catch (error) {
-      throw new Error(`Error while requesting all entities: ${error}`);
-    }
-  }
-
-  async findOne(id: string | number, fetchOpts?: RequestInit): Promise<T> {
-    try {
-      const response = await fetch(`${this.basePath}/${id}`, {
-        method: 'GET',
-        headers: {
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-
-      const json: T = await response.json();
-
-      return json;
-    } catch (error) {
-      throw new Error(`Error while requesting a single entity: ${error}`);
-    }
-  }
-
-  async add(t: T, fetchOpts?: RequestInit): Promise<T> {
-    try {
-      const response = await fetch(this.basePath, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...getCsrfTokenHeader(),
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        body: JSON.stringify(t),
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-
-      const json: T = await response.json();
-
-      return json;
-    } catch (error) {
-      throw new Error(`Error while creating an entity: ${error}`);
-    }
-  }
-
-  async update(t: T, fetchOpts?: RequestInit): Promise<T> {
-    try {
-      const response = await fetch(`${this.basePath}/${t.id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          ...getCsrfTokenHeader(),
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        body: JSON.stringify(t),
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-
-      const json: T = await response.json();
-
-      return json;
-    } catch (error) {
-      throw new Error(`Error while updating an entity: ${error}`);
-    }
-  }
-
-  async updatePartial(t: Partial<T>, fetchOpts?: RequestInit): Promise<T> {
-    try {
-      const response = await fetch(`${this.basePath}/${t.id}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          ...getCsrfTokenHeader(),
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        body: JSON.stringify(t),
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-
-      const json: T = await response.json();
-
-      return json;
-    } catch (error) {
-      throw new Error(`Error while updating an entity partially: ${error}`);
-    }
-  }
-
-  async delete(id: string | number, fetchOpts?: RequestInit): Promise<void> {
-    try {
-      const response = await fetch(`${this.basePath}/${id}`, {
-        method: 'DELETE',
-        headers: {
-          ...getBearerTokenHeader(this.keycloak)
-        },
-        ...fetchOpts
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error status: ${response.status}`);
-      }
-    } catch (error) {
-      throw new Error(`Error while deleting an entity: ${error}`);
-    }
   }
 
 }

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -1,7 +1,6 @@
-import Keycloak from 'keycloak-js';
-
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
 export interface GraphQLQueryObject {
   query: string;
@@ -12,30 +11,22 @@ export interface GraphQLQueryObject {
 
 export interface GraphQLResponse<T> {
   data: {
-    [key: string]: T[];
+    [key: string]: T;
   };
   errors?: any;
 }
 
-export interface GraphQLServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type GraphQLServiceOpts = GenericServiceOpts;
 
-export class GraphQLService {
-
-  private basePath: string;
-
-  private keycloak?: Keycloak;
+export class GraphQLService extends GenericService {
 
   constructor(opts: GraphQLServiceOpts = {
     basePath: '/graphql'
   }) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
-  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<{[key: string]: T[]}> {
+  async sendQuery<T>(query: GraphQLQueryObject, fetchOpts?: RequestInit): Promise<{[key: string]: T}> {
     try {
       const response = await fetch(this.basePath, {
         method: 'POST',

--- a/src/service/GroupService/index.spec.ts
+++ b/src/service/GroupService/index.spec.ts
@@ -1,5 +1,5 @@
 import Group, { KeycloakGroupRepresentation } from '../../model/Group';
-import GenericService from '../GenericService';
+import GenericEntityService from '../GenericEntityService';
 import GroupService from '.';
 
 describe('GroupService', () => {
@@ -14,11 +14,11 @@ describe('GroupService', () => {
   });
 
   it('extends the GenericService', () => {
-    expect(service instanceof GenericService).toBeTruthy();
+    expect(service instanceof GenericEntityService).toBeTruthy();
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/groups');
+    expect(service.getBasePath()).toEqual('/groups');
   });
 
 });

--- a/src/service/GroupService/index.ts
+++ b/src/service/GroupService/index.ts
@@ -1,10 +1,10 @@
 import Group, { KeycloakGroupRepresentation,ProviderGroupDetails } from '../../model/Group';
-import GenericService, { GenericServiceOpts } from '../GenericService';
+import GenericEntityService, { GenericEntityServiceOpts } from '../GenericEntityService';
 
 export class GroupService<T extends Group<S>,
-  S extends ProviderGroupDetails = KeycloakGroupRepresentation> extends GenericService<T> {
+  S extends ProviderGroupDetails = KeycloakGroupRepresentation> extends GenericEntityService<T> {
 
-  constructor(opts: GenericServiceOpts = {
+  constructor(opts: GenericEntityServiceOpts = {
     basePath: '/groups'
   }) {
     super(opts);

--- a/src/service/ImageFileService/index.spec.ts
+++ b/src/service/ImageFileService/index.spec.ts
@@ -27,7 +27,7 @@ describe('ImageFileService', () => {
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/imagefiles');
+    expect(service.getBasePath()).toEqual('/imagefiles');
   });
 
 

--- a/src/service/ImageFileService/index.ts
+++ b/src/service/ImageFileService/index.ts
@@ -24,9 +24,7 @@ export class ImageFileService<T extends ImageFile> extends GenericFileService<T>
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const blob: Blob = await response.blob();
-
-      return blob;
+      return await response.blob();
     } catch (error) {
       throw new Error(`Error while requesting a single entity: ${error}`);
     }

--- a/src/service/LayerService/index.spec.ts
+++ b/src/service/LayerService/index.spec.ts
@@ -1,5 +1,5 @@
 import Layer from '../../model/Layer';
-import GenericService from '../GenericService';
+import GenericEntityService from '../GenericEntityService';
 import LayerService from '.';
 
 describe('LayerService', () => {
@@ -14,11 +14,11 @@ describe('LayerService', () => {
   });
 
   it('extends the GenericService', () => {
-    expect(service instanceof GenericService).toBeTruthy();
+    expect(service instanceof GenericEntityService).toBeTruthy();
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/layers');
+    expect(service.getBasePath()).toEqual('/layers');
   });
 
 });

--- a/src/service/LayerService/index.ts
+++ b/src/service/LayerService/index.ts
@@ -1,9 +1,9 @@
 import Layer from '../../model/Layer';
-import GenericService, { GenericServiceOpts } from '../GenericService';
+import GenericEntityService, { GenericEntityServiceOpts } from '../GenericEntityService';
 
-export class LayerService<T extends Layer> extends GenericService<T> {
+export class LayerService<T extends Layer> extends GenericEntityService<T> {
 
-  constructor(opts: GenericServiceOpts = {
+  constructor(opts: GenericEntityServiceOpts = {
     basePath: '/layers'
   }) {
     super(opts);

--- a/src/service/OpenAPIService/index.ts
+++ b/src/service/OpenAPIService/index.ts
@@ -1,29 +1,18 @@
-import Keycloak from 'keycloak-js';
-import {
-  OpenAPIV2,
-  OpenAPIV3
-} from 'openapi-types';
+import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
 export type OpenApiVersion = 'v2' | 'v3';
 
-export interface OpenAPIServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type OpenAPIServiceOpts = GenericServiceOpts;
 
-export class OpenAPIService {
-
-  private basePath: string;
-
-  private keycloak?: Keycloak;
+export class OpenAPIService extends GenericService {
 
   constructor(opts: OpenAPIServiceOpts = {
     basePath: '/'
   }) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
   async getApiDocs(version: OpenApiVersion = 'v2', fetchOpts?: RequestInit):

--- a/src/service/PermissionService/index.ts
+++ b/src/service/PermissionService/index.ts
@@ -1,5 +1,3 @@
-import Keycloak from 'keycloak-js';
-
 import PermissionCollectionType from '../../model/enum/PermissionCollectionType';
 import GroupClassPermission from '../../model/security/GroupClassPermission';
 import GroupInstancePermission from '../../model/security/GroupInstancePermission';
@@ -7,21 +5,14 @@ import UserClassPermission from '../../model/security/UserClassPermission';
 import UserInstancePermission from '../../model/security/UserInstancePermission';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { GenericService, GenericServiceOpts } from '../GenericService';
 
-export interface PermissionServiceOpts {
-  basePath: string;
-  keycloak?: Keycloak;
-}
+export type PermissionServiceOpts = GenericServiceOpts;
 
-export class PermissionService {
-
-  basePath: string;
-
-  keycloak?: Keycloak;
+export class PermissionService extends GenericService {
 
   constructor(opts: PermissionServiceOpts) {
-    this.basePath = opts.basePath;
-    this.keycloak = opts.keycloak;
+    super(opts);
   }
 
   async getUserInstancePermissions(id: string | number, fetchOpts?: RequestInit): Promise<UserInstancePermission[]> {
@@ -38,9 +29,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserInstancePermission[] = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the user instance permissions: ${error}`);
     }
@@ -60,9 +49,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: GroupInstancePermission[] = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the group instance permissions: ${error}`);
     }
@@ -82,9 +69,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserClassPermission[] = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the user class permissions: ${error}`);
     }
@@ -104,9 +89,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: GroupClassPermission[] = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the group class permissions: ${error}`);
     }
@@ -127,9 +110,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserInstancePermission = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the user instance permission: ${error}`);
     }
@@ -150,9 +131,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserInstancePermission = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the group instance permission: ${error}`);
     }
@@ -173,9 +152,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserInstancePermission = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the user class permission: ${error}`);
     }
@@ -196,9 +173,7 @@ export class PermissionService {
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json: UserInstancePermission = await response.json();
-
-      return json;
+      return await response.json();
     } catch (error) {
       throw new Error(`Error while requesting the group class permission: ${error}`);
     }

--- a/src/service/SHOGunAPIClient.ts
+++ b/src/service/SHOGunAPIClient.ts
@@ -33,7 +33,6 @@ export interface SHOGunAPIClientOpts {
 export class SHOGunAPIClient {
 
   private basePath: string;
-
   private keycloak?: Keycloak;
 
   private cacheService?: CacheService;

--- a/src/service/UserService/index.spec.ts
+++ b/src/service/UserService/index.spec.ts
@@ -1,5 +1,5 @@
-import User, { KeycloakUserRepresentation } from '../../model/User';
-import GenericService from '../GenericService';
+import User from '../../model/User';
+import GenericEntityService from '../GenericEntityService';
 import UserService from '.';
 
 describe('UserService', () => {
@@ -14,11 +14,11 @@ describe('UserService', () => {
   });
 
   it('extends the GenericService', () => {
-    expect(service instanceof GenericService).toBeTruthy();
+    expect(service instanceof GenericEntityService).toBeTruthy();
   });
 
   it('has set the correct default path', () => {
-    expect(service.basePath).toEqual('/users');
+    expect(service.getBasePath()).toEqual('/users');
   });
 
 });

--- a/src/service/UserService/index.ts
+++ b/src/service/UserService/index.ts
@@ -1,10 +1,10 @@
 import User, { KeycloakUserRepresentation, ProviderUserDetails } from '../../model/User';
-import GenericService, { GenericServiceOpts } from '../GenericService';
+import GenericEntityService, { GenericEntityServiceOpts } from '../GenericEntityService';
 
 export class UserService<T extends User<S>,
-  S extends ProviderUserDetails = KeycloakUserRepresentation> extends GenericService<T> {
+  S extends ProviderUserDetails = KeycloakUserRepresentation> extends GenericEntityService<T> {
 
-  constructor(opts: GenericServiceOpts = {
+  constructor(opts: GenericEntityServiceOpts = {
     basePath: '/users'
   }) {
     super(opts);


### PR DESCRIPTION
This PR (BREAKING CHANGE) introduces an abstract base service `GenericService` holding `basePath` and `keycloak` instance for all subclasses.
Beside, the datatype of `GraphQLResponse` (field `data`) has been changed from `array` to a single one (also a breaking change)

Plz review @terrestris/devs  