### PR TITLE
Support paging in `findAll` service methods

### DIFF
--- a/src/model/Page.ts
+++ b/src/model/Page.ts
@@ -1,0 +1,31 @@
+import BaseEntity from './BaseEntity';
+
+export interface Sort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}
+
+export interface Pageable {
+  offset: number;
+  pageNumber: number;
+  pageSize: number;
+  paged: boolean;
+  sort: Sort;
+  unpaged: boolean;
+}
+
+export interface Page<T extends BaseEntity> {
+  content: T[];
+  empty: boolean;
+  first: boolean;
+  last: boolean;
+  // eslint-disable-next-line id-blacklist
+  number: number;
+  numberOfElements: number;
+  pageable: Pageable;
+  size: number;
+  sort: Sort;
+  totalElements: number;
+  totalPages: number;
+}

--- a/src/service/GenericEntityService/index.spec.ts
+++ b/src/service/GenericEntityService/index.spec.ts
@@ -75,7 +75,7 @@ describe('GenericService', () => {
 
     const resp = await service.findAll();
 
-    expect(resp).toEqual(response.content);
+    expect(resp).toEqual(response);
   });
 
   it('throws an error if all entities couldn\'t be fetched (findAll)', async () => {

--- a/src/service/GenericEntityService/index.spec.ts
+++ b/src/service/GenericEntityService/index.spec.ts
@@ -59,6 +59,93 @@ describe('GenericService', () => {
     });
   });
 
+  it('sends all required parameters to return all paged entities (findAll)', async () => {
+    fetchMock = fetchSpy(successResponse([]));
+
+    await service.findAll({
+      page: 0
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0', {
+      headers: {},
+      method: 'GET'
+    });
+
+    fetchMock.mockClear();
+
+    await service.findAll({
+      page: 0,
+      size: 10
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0&size=10', {
+      headers: {},
+      method: 'GET'
+    });
+
+    fetchMock.mockClear();
+
+    await service.findAll({
+      page: 0,
+      size: 10,
+      sort: {
+        properties: ['a']
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0&size=10&sort=a', {
+      headers: {},
+      method: 'GET'
+    });
+
+    fetchMock.mockClear();
+
+    await service.findAll({
+      page: 0,
+      size: 10,
+      sort: {
+        properties: ['a', 'b']
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0&size=10&sort=a%2Cb', {
+      headers: {},
+      method: 'GET'
+    });
+
+    fetchMock.mockClear();
+
+    await service.findAll({
+      page: 0,
+      size: 10,
+      sort: {
+        properties: ['a', 'b'],
+        order: 'asc'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0&size=10&sort=a%2Cb%2Casc', {
+      headers: {},
+      method: 'GET'
+    });
+
+    fetchMock.mockClear();
+
+    await service.findAll({
+      page: 0,
+      size: 10,
+      sort: {
+        properties: ['a', 'b'],
+        order: 'desc'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/dummy?page=0&size=10&sort=a%2Cb%2Cdesc', {
+      headers: {},
+      method: 'GET'
+    });
+  });
+
   it('returns all entities (findAll)', async () => {
     const response = {
       content: [

--- a/src/service/GenericEntityService/index.ts
+++ b/src/service/GenericEntityService/index.ts
@@ -1,4 +1,5 @@
 import BaseEntity from '../../model/BaseEntity';
+import { Page } from '../../model/Page';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
 import { GenericServiceOpts } from '../GenericService';
@@ -12,7 +13,7 @@ export abstract class GenericEntityService<T extends BaseEntity> extends Permiss
     super(opts);
   }
 
-  async findAll(fetchOpts?: RequestInit): Promise<T[]> {
+  async findAll(fetchOpts?: RequestInit): Promise<Page<T>> {
     try {
       const response = await fetch(this.basePath, {
         method: 'GET',
@@ -26,9 +27,7 @@ export abstract class GenericEntityService<T extends BaseEntity> extends Permiss
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      const json = await response.json();
-
-      return json.content;
+      return await response.json() as Page<T>;
     } catch (error) {
       throw new Error(`Error while requesting all entities: ${error}`);
     }

--- a/src/service/GenericEntityService/index.ts
+++ b/src/service/GenericEntityService/index.ts
@@ -2,7 +2,7 @@ import BaseEntity from '../../model/BaseEntity';
 import { Page } from '../../model/Page';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
-import { GenericServiceOpts } from '../GenericService';
+import { GenericServiceOpts, PageOpts } from '../GenericService';
 import PermissionService from '../PermissionService';
 
 export type GenericEntityServiceOpts = GenericServiceOpts;
@@ -13,9 +13,9 @@ export abstract class GenericEntityService<T extends BaseEntity> extends Permiss
     super(opts);
   }
 
-  async findAll(fetchOpts?: RequestInit): Promise<Page<T>> {
+  async findAll(pageOpts?: PageOpts, fetchOpts?: RequestInit): Promise<Page<T>> {
     try {
-      const response = await fetch(this.basePath, {
+      const response = await fetch(this.getPageUrl(pageOpts), {
         method: 'GET',
         headers: {
           ...getBearerTokenHeader(this.keycloak)

--- a/src/service/GenericFileService/index.ts
+++ b/src/service/GenericFileService/index.ts
@@ -1,4 +1,5 @@
 import SHOGunFile from '../../model/File';
+import { Page } from '../../model/Page';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
 import { GenericService, GenericServiceOpts } from '../GenericService';
@@ -11,7 +12,7 @@ export abstract class GenericFileService<T extends SHOGunFile> extends GenericSe
     super(opts);
   }
 
-  async findAll(fetchOpts?: RequestInit): Promise<T[]> {
+  async findAll(fetchOpts?: RequestInit): Promise<Page<T>> {
     try {
       const response = await fetch(this.basePath, {
         method: 'GET',
@@ -25,7 +26,7 @@ export abstract class GenericFileService<T extends SHOGunFile> extends GenericSe
         throw new Error(`HTTP error status: ${response.status}`);
       }
 
-      return await response.json() ;
+      return await response.json() as Page<T>;
     } catch (error) {
       throw new Error(`Error while requesting all entities: ${error}`);
     }

--- a/src/service/GenericFileService/index.ts
+++ b/src/service/GenericFileService/index.ts
@@ -2,7 +2,7 @@ import SHOGunFile from '../../model/File';
 import { Page } from '../../model/Page';
 import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
-import { GenericService, GenericServiceOpts } from '../GenericService';
+import { GenericService, GenericServiceOpts, PageOpts } from '../GenericService';
 
 export type GenericFileServiceOpts = GenericServiceOpts;
 
@@ -12,9 +12,9 @@ export abstract class GenericFileService<T extends SHOGunFile> extends GenericSe
     super(opts);
   }
 
-  async findAll(fetchOpts?: RequestInit): Promise<Page<T>> {
+  async findAll(pageOpts?: PageOpts, fetchOpts?: RequestInit): Promise<Page<T>> {
     try {
-      const response = await fetch(this.basePath, {
+      const response = await fetch(this.getPageUrl(pageOpts), {
         method: 'GET',
         headers: {
           ...getBearerTokenHeader(this.keycloak)

--- a/src/service/GenericService/index.ts
+++ b/src/service/GenericService/index.ts
@@ -1,4 +1,16 @@
+import { UrlUtil } from '@terrestris/base-util';
 import Keycloak from 'keycloak-js';
+
+export type PageSorter = {
+  properties: string[];
+  order?: 'asc' | 'desc';
+};
+
+export type PageOpts = {
+  page?: number;
+  size?: number;
+  sort?: PageSorter;
+};
 
 export type GenericServiceOpts = {
   basePath: string;
@@ -15,6 +27,30 @@ export abstract class GenericService {
     this.keycloak = opts.keycloak;
   }
 
+  protected getPageUrl(pageOpts?: PageOpts) {
+    const opts: any = {};
+
+    if (Number.isFinite(pageOpts?.page)) {
+      opts.page = pageOpts?.page;
+    }
+
+    if (Number.isFinite(pageOpts?.size)) {
+      opts.size = pageOpts?.size;
+    }
+
+    if (pageOpts?.sort) {
+      const sortValue = [...pageOpts.sort.properties, pageOpts.sort.order].filter(a => a);
+      if (sortValue.length > 0) {
+        opts.sort = `${sortValue.join(',')}`;
+      }
+    }
+
+    if (Object.keys(opts).length === 0) {
+      return this.basePath;
+    }
+
+    return `${this.basePath}?${UrlUtil.objectToRequestString(opts)}`;
+  }
 }
 
 export default GenericService;

--- a/src/service/SHOGunAPIClient.spec.ts
+++ b/src/service/SHOGunAPIClient.spec.ts
@@ -90,6 +90,6 @@ describe('SHOGunAPIClient', () => {
 
     const apps = await client.application<MyApplication>().findAll();
 
-    expect(apps[0].clientConfig?.newField).toEqual(1);
+    expect(apps.content[0].clientConfig?.newField).toEqual(1);
   });
 });


### PR DESCRIPTION
This enables support for paging in the `findAll()` service methods and thus enables to make use of [!606](https://github.com/terrestris/shogun/pull/606).

**BREAKING CHANGES:** 

- The signature of the `findAll()` methods changes from `findAll((fetchOpts?: RequestInit)): T[]` to `findAll(pageOpts?: PageOpts, fetchOpts?: RequestInit): Page<T>`

Please review @terrestris/devs.