### PR TITLE
Set correct layer type name for WMSTIME

### DIFF
--- a/src/model/enum/LayerType.ts
+++ b/src/model/enum/LayerType.ts
@@ -1,3 +1,3 @@
-export type LayerType = 'TILEWMS' | 'VECTORTILE' | 'WFS' | 'WMS' | 'WMTS' | 'XYZ' | 'WMSTime';
+export type LayerType = 'TILEWMS' | 'VECTORTILE' | 'WFS' | 'WMS' | 'WMTS' | 'XYZ' | 'WMSTIME';
 
 export default LayerType;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -215,12 +215,12 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
       return this.parseWFSLayer(layer, projection);
     }
 
-    if (layer.type === 'WMSTime') {
+    if (layer.type === 'WMSTIME') {
       return await this.parseWMSTimeLayer(layer);
     }
 
     // TODO Add support for VECTORTILE and XYZ
-    throw new Error('Currently only WMTS, WMS, TILEWMS, WFS and WMSTime layers are supported.');
+    throw new Error('Currently only WMTS, WMS, TILEWMS, WFS and WMSTIME layers are supported.');
   }
 
   parseImageLayer(layer: S) {


### PR DESCRIPTION
**BREAKING CHANGE:** This renames the public enum from `WMSTime` to `WMSTIME` (which wasn't available in SHOGun before anyway).

Requires [!715](https://github.com/terrestris/shogun/pull/715).

Please review @terrestris/devs.
