### PR TITLE
Add non-null assertion operator

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -594,7 +594,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
     olLayer.set('propertyConfig', layer.clientConfig?.propertyConfig);
     olLayer.set('downloadConfig', layer.clientConfig?.downloadConfig);
     olLayer.set('searchConfig', layer.clientConfig?.searchConfig);
-    olLayer.set('legendUrl', layer.sourceConfig.legendUrl);
+    olLayer.set('legendUrl', layer.sourceConfig?.legendUrl);
     olLayer.set('hoverable', layer.clientConfig?.hoverable);
     olLayer.set('useBearerToken', layer.sourceConfig?.useBearerToken);
     olLayer.set('editable', layer.clientConfig?.editable);


### PR DESCRIPTION
Even if typed as required, `sourceConfig` might be empty if returned otherwise from the server.

Please review @terrestris/devs.