### PR TITLE
Refactor parse layer tree

### DIFF
--- a/src/parser/SHOGunApplicationUtil.spec.ts
+++ b/src/parser/SHOGunApplicationUtil.spec.ts
@@ -16,20 +16,12 @@ import SHOGunAPIClient from '../service/SHOGunAPIClient';
 import SHOGunApplicationUtil from './SHOGunApplicationUtil';
 
 describe('SHOGunApplicationUtil', () => {
-  let fetchMock: jest.SpyInstance;
   let util: SHOGunApplicationUtil<Application, Layer>;
 
   beforeEach(() => {
     util = new SHOGunApplicationUtil<Application, Layer>({
       client: new SHOGunAPIClient()
     });
-  });
-
-  afterEach(() => {
-    if (fetchMock) {
-      fetchMock.mockReset();
-      fetchMock.mockRestore();
-    }
   });
 
   it('is defined', () => {

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -73,7 +73,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
 
     const projection = mapView?.projection || 'EPSG:3857';
     const zoom = mapView?.zoom || 0;
-    const resolutions = mapView?.resolutions || [];
+    const resolutions = mapView?.resolutions;
 
     let center;
     if (mapView?.center && mapView.center.length === 2) {


### PR DESCRIPTION
This refactors the `parseLayerTree` function by introducing a new function `parseLayerTreeNodes` that can has the same functionality, but without calling shogun, instead it gets the layers array passed in.

This also contains a small fix where resolutions was initialized with an empty array which was causing the map to have no available resolutions at all. No it remains undefined and the default resolutions of OpenLayers are used.