### PR TITLE
fix: ignore checked attribute for groups

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -120,8 +120,7 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
           const nodes = await this.parseNodes(layerTree.children, layers, projection, keepClientConfig);
 
           return new OlLayerGroup({
-            layers: nodes.reverse(),
-            visible: layerTree.checked
+            layers: nodes.reverse()
           });
         }
       } catch (e) {
@@ -217,11 +216,8 @@ class SHOGunApplicationUtil<T extends Application, S extends Layer> {
   async parseFolder(el: DefaultLayerTree, layers: S[], projection?: OlProjectionLike, keepClientConfig = false) {
     const layersInFolder = await this.parseNodes(el.children, layers, projection, keepClientConfig);
 
-    const visible = el.checked || layersInFolder.some(layer => layer.getVisible());
-
     const folder = new OlLayerGroup({
-      layers: layersInFolder.reverse(),
-      visible
+      layers: layersInFolder.reverse()
     });
 
     folder.set('name', el.title);


### PR DESCRIPTION
The checked attribute should be ignored for groups. The attribute comes from the [layerTree](https://github.com/terrestris/shogun/blob/main/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java) jsonb property of the Layer Model.

The checked state in the tree for a layer group is always dependent on the visibility of the children. If all children are visible the group is checked, if only some children are visible the group is partly checked and if none are visible the group is not checked.

The group visibility is never changed in the react-geo LayerTree, and it would be tricky to do so. It is better to ignore this value for groups and always keep them visible. If you want to check a complete group, just check all children.

Here is an example with this change, when only one child is checked:

![image](https://github.com/terrestris/shogun-util/assets/8100558/81524175-29f7-41cf-ac23-08f07d07f259)

And here is an example where all children are checked:

![image](https://github.com/terrestris/shogun-util/assets/8100558/6c5cf02b-236c-46ca-9caa-5b806d205c44)
