### PR TITLE
fix: change return types of header functions

### DIFF
--- a/src/security/getBearerTokenHeader.ts
+++ b/src/security/getBearerTokenHeader.ts
@@ -1,14 +1,10 @@
 import Keycloak from 'keycloak-js';
 
-export interface BearerTokenHeader {
-  'Authorization': string;
-}
-
-export const getBearerTokenHeader = (keycloak?: Keycloak): BearerTokenHeader | undefined => {
+export const getBearerTokenHeader = (keycloak?: Keycloak): Record<string, string> => {
   let accessToken = keycloak?.token;
 
   if (!accessToken) {
-    return;
+    return {};
   }
 
   return {

--- a/src/security/getCsrfTokenHeader.ts
+++ b/src/security/getCsrfTokenHeader.ts
@@ -1,10 +1,6 @@
 import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
-export interface CsrfTokenHeader {
-  'X-XSRF-TOKEN': string;
-}
-
-export const getCsrfTokenHeader = (): CsrfTokenHeader | undefined => {
+export const getCsrfTokenHeader = (): Record<string, string> => {
   let csrfToken = CsrfUtil.getCsrfValueFromCookie();
 
   if (!csrfToken) {
@@ -12,7 +8,7 @@ export const getCsrfTokenHeader = (): CsrfTokenHeader | undefined => {
   }
 
   if (!csrfToken) {
-    return;
+    return {};
   }
 
   return {


### PR DESCRIPTION
This changes the return types of the header functions so they can be used in a fetch without any type casts:

![image](https://github.com/terrestris/shogun-util/assets/8100558/a0d1265e-bdc8-4409-8089-52f999182dd8)

Also it switches `undefined` from the return type to an empty object so you can easily do something like this:

```typescript
const headers: HeadersInit = {
  ...getBearerTokenHeader(),
  'other-header': 'value'
}
```