### PR TITLE
feat(layer): use generics for source and client config

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -59,37 +59,43 @@ export interface SearchConfig {
 }
 
 export interface DefaultLayerClientConfig {
-  minResolution?: number;
-  maxResolution?: number;
-  hoverable?: boolean;
-  searchable?: boolean;
-  searchConfig?: SearchConfig;
-  propertyConfig?: DefaultLayerPropertyConfig[];
-  featureInfoFormConfig?: PropertyFormTabConfig<PropertyFormItemReadConfig>[];
+  crossOrigin?: string;
+  downloadConfig?: DownloadConfig[];
   editFormConfig?: PropertyFormTabConfig<PropertyFormItemEditDefaultConfig |
     PropertyFormItemEditReferenceTableConfig>[];
-  crossOrigin?: string;
-  opacity?: number;
-  downloadConfig?: DownloadConfig[];
   editable?: boolean;
+  featureInfoFormConfig?: PropertyFormTabConfig<PropertyFormItemReadConfig>[];
+  hoverable?: boolean;
+  maxResolution?: number;
+  minResolution?: number;
+  opacity?: number;
+  propertyConfig?: DefaultLayerPropertyConfig[];
+  searchConfig?: SearchConfig;
+  searchable?: boolean;
 }
 
-export interface LayerArgs extends BaseEntityArgs {
+export interface LayerArgs<
+  D extends DefaultLayerClientConfig,
+  S extends DefaultLayerSourceConfig
+> extends BaseEntityArgs {
   name: string;
-  clientConfig?: DefaultLayerClientConfig;
-  sourceConfig: DefaultLayerSourceConfig;
+  clientConfig?: D;
+  sourceConfig: S;
   features?: FeatureCollection;
   type: LayerType;
 }
 
-export default class Layer extends BaseEntity {
+export default class Layer<
+  D extends DefaultLayerClientConfig = DefaultLayerClientConfig,
+  S extends DefaultLayerSourceConfig = DefaultLayerSourceConfig,
+> extends BaseEntity {
   name: string;
-  clientConfig?: DefaultLayerClientConfig;
-  sourceConfig: DefaultLayerSourceConfig;
+  clientConfig?: D;
+  sourceConfig: S;
   features?: FeatureCollection;
   type: LayerType;
 
-  constructor({id, created, modified, clientConfig, features, name, sourceConfig, type}: LayerArgs) {
+  constructor({id, created, modified, clientConfig, features, name, sourceConfig, type}: LayerArgs<D, S>) {
     super({id, created, modified});
 
     this.name = name;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -47,7 +47,10 @@ export interface SHOGunApplicationUtilOpts {
   client?: SHOGunAPIClient;
 }
 
-class SHOGunApplicationUtil<T extends Application, S extends Layer> {
+class SHOGunApplicationUtil<
+  T extends Application,
+  S extends Layer
+> {
 
   private readonly client: SHOGunAPIClient | undefined;
 


### PR DESCRIPTION
This PR introduces generics for sub types of `LayerClientConfig` and `LayerSourceConfig` that can be passed to layer instances. Herewith, layer classes having custom layer client configs (for example) can be used with the `SHOGunAPIClient`.

```
export default class ProjectLayer extends Layer<ProjectLayerClientConfig, DefaultLayerSourceConfig> {
  constructor(layerArgs: LayerArgs<ProjectLayerClientConfig, DefaultLayerSourceConfig>) {
    super(layerArgs);
  }
}
```
Plz review @terrestris/devs 
