### PR TITLE
Improve graphql error handling

### DIFF
--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -35,7 +35,7 @@ import Logger from '@terrestris/base-util/dist/Logger';
 import { UrlUtil } from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
 import CapabilitiesUtil from '@terrestris/ol-util/dist/CapabilitiesUtil/CapabilitiesUtil';
 import { MapUtil } from '@terrestris/ol-util/dist/MapUtil/MapUtil';
-import ProjectionUtil, { defaultProj4CrsDefinitions } from '@terrestris/ol-util/dist/ProjectionUtil/ProjectionUtil';
+import { ProjectionUtil, defaultProj4CrsDefinitions } from '@terrestris/ol-util/dist/ProjectionUtil/ProjectionUtil';
 
 import {
   allLayersByIds

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -42,7 +42,7 @@ export class GraphQLService extends GenericService {
       const {data, errors } = await response.json() as GraphQLResponse<T>;
 
       if (errors?.length > 0) {
-        throw new Error(`GraphQL error: ${JSON.stringify(errors, null, "\t")}`);
+        throw new Error(`GraphQL error: ${JSON.stringify(errors, null, '\t')}`);
       }
 
       return data;

--- a/src/service/GraphQLService/index.ts
+++ b/src/service/GraphQLService/index.ts
@@ -42,7 +42,7 @@ export class GraphQLService extends GenericService {
       const {data, errors } = await response.json() as GraphQLResponse<T>;
 
       if (errors?.length > 0) {
-        throw new Error(`Error response: ${errors}`);
+        throw new Error(`GraphQL error: ${JSON.stringify(errors, null, "\t")}`);
       }
 
       return data;


### PR DESCRIPTION
This prints the graphql error message as formatted JSON instead of `Object object`.

@terrestris/devs Please review