### PR TITLE
Adds method to parse map interactions

### DIFF
--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -10,6 +10,18 @@ import {
   DefaultLayerSourceConfig
 } from './Layer';
 
+export type MapInteraction = 'DragRotate' |
+'DragRotateAndZoom' |
+'DblClickDragZoom' |
+'DoubleClickZoom' |
+'DragPan' |
+'PinchRotate' |
+'PinchZoom' |
+'KeyboardPan' |
+'KeyboardZoom' |
+'MouseWheelZoom' |
+'DragZoom';
+
 export interface DefaultApplicationTheme {
   primaryColor?: string;
   secondaryColor?: string;
@@ -59,6 +71,7 @@ export interface DefaultApplicationClientConfig<
   ApplicationTheme extends DefaultApplicationTheme = DefaultApplicationTheme
 > {
   mapView: MapView;
+  mapInteractions?: MapInteraction[];
   description?: string;
   legal?: LegalConfig;
   theme?: ApplicationTheme;


### PR DESCRIPTION
This adds the `parseMapInteractions` method. It receives an applicationConfig and returns an array of openlayers Interactions. If no `mapInteractions` key is found in the `clientConfig` the default interactions will be used. If the array is empty the map will have no interactions and will have a static extent.

Test included :microscope: 