### PR TITLE
fix: mock CSRF meta elements in tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,8 @@
 global.fetch = jest.fn();
+
+['_csrf_header', '_csrf'].forEach(csrfMeta => {
+  const meta = document.createElement('meta');
+  meta.setAttribute('name', csrfMeta);
+  meta.setAttribute('content', Math.floor(Math.random() * Date.now()).toString(36));
+  document.head.appendChild(meta);
+});

--- a/src/service/AuthService/index.spec.ts
+++ b/src/service/AuthService/index.spec.ts
@@ -3,6 +3,7 @@ import fetchSpy, {
   successResponse
 } from '../../spec/fetchSpy';
 import AuthService from '.';
+import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
 describe('AuthService', () => {
   let fetchMock: jest.SpyInstance;
@@ -28,9 +29,12 @@ describe('AuthService', () => {
 
     await service.logout();
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/sso/logout', {
       credentials: 'same-origin',
-      headers: {},
+      headers: {
+        'X-XSRF-TOKEN': csrfHeaderValue
+      },
       method: 'POST'
     });
   });

--- a/src/service/CacheService/index.spec.ts
+++ b/src/service/CacheService/index.spec.ts
@@ -3,6 +3,7 @@ import fetchSpy, {
   successResponse
 } from '../../spec/fetchSpy';
 import CacheService from '.';
+import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
 describe('AppInfoService', () => {
   let fetchMock: jest.SpyInstance;
@@ -27,9 +28,11 @@ describe('AppInfoService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.evictCache();
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/cache/evict', {
-      headers: {},
+      headers: {
+        'X-XSRF-TOKEN': csrfHeaderValue
+      },
       method: 'POST'
     });
   });

--- a/src/service/GenericEntityService/index.spec.ts
+++ b/src/service/GenericEntityService/index.spec.ts
@@ -1,6 +1,7 @@
 import BaseEntity, { BaseEntityArgs } from '../../model/BaseEntity';
 import fetchSpy, { failureResponse, successResponse } from '../../spec/fetchSpy';
 import GenericService, { GenericEntityServiceOpts } from '.';
+import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
 interface DummyEntityArgs extends BaseEntityArgs {
   dummyField?: string;
@@ -204,11 +205,12 @@ describe('GenericService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.add({ dummyField: 'dummyValue' });
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy', {
       body: '{\"dummyField\":\"dummyValue\"}',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'POST'
     });
@@ -236,7 +238,7 @@ describe('GenericService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     const resp = await service.delete(1);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/1', {
       headers: {},
       method: 'DELETE'
@@ -259,11 +261,12 @@ describe('GenericService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.update({ id: 1, dummyField: 'dummyValue' });
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/1', {
       body: '{\"id\":1,\"dummyField\":\"dummyValue\"}',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'PUT'
     });
@@ -291,11 +294,12 @@ describe('GenericService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.updatePartial({ id: 1, dummyField: 'dummyValue' });
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/1', {
       body: '{\"id\":1,\"dummyField\":\"dummyValue\"}',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'PATCH'
     });
@@ -366,7 +370,6 @@ describe('GenericService', () => {
 
       await expect(service.setPublic(1)).rejects.toThrow();
     });
-
 
   });
 });

--- a/src/service/GenericFileService/index.spec.ts
+++ b/src/service/GenericFileService/index.spec.ts
@@ -1,6 +1,7 @@
 import BaseEntity, { BaseEntityArgs } from '../../model/BaseEntity';
 import fetchSpy, { failureResponse, successResponse } from '../../spec/fetchSpy';
 import GenericFileService, { GenericFileServiceOpts } from '.';
+import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
 interface DummyEntityArgs extends BaseEntityArgs {
   dummyField?: string;
@@ -114,10 +115,12 @@ describe('GenericFileService', () => {
 
     const body = new FormData();
     body.append('file', file);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/upload', {
       body: body,
-      headers: {},
+      headers: {
+        'X-XSRF-TOKEN': csrfHeaderValue
+      },
       method: 'POST'
     });
   });
@@ -131,9 +134,12 @@ describe('GenericFileService', () => {
     const body = new FormData();
     body.append('file', file);
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/uploadToFileSystem', {
       body: body,
-      headers: {},
+      headers: {
+        'X-XSRF-TOKEN': csrfHeaderValue
+      },
       method: 'POST'
     });
   });
@@ -161,6 +167,7 @@ describe('GenericFileService', () => {
 
     await service.delete('db5f69fa-e8f6-42a6-a305-d2555d7d4d08');
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/dummy/db5f69fa-e8f6-42a6-a305-d2555d7d4d08', {
       headers: {},
       method: 'DELETE'

--- a/src/service/ImageFileService/index.ts
+++ b/src/service/ImageFileService/index.ts
@@ -1,5 +1,5 @@
 import ImageFile from '../../model/ImageFile';
-import { getCsrfTokenHeader } from '../../security/getCsrfTokenHeader';
+import { getBearerTokenHeader } from '../../security/getBearerTokenHeader';
 import GenericFileService, { GenericFileServiceOpts } from '../GenericFileService';
 
 export class ImageFileService<T extends ImageFile> extends GenericFileService<T> {
@@ -15,7 +15,7 @@ export class ImageFileService<T extends ImageFile> extends GenericFileService<T>
       const response = await fetch(`${this.basePath}/${fileUuid}/thumbnail`, {
         method: 'GET',
         headers: {
-          ...getCsrfTokenHeader()
+          ...getBearerTokenHeader(this.keycloak),
         },
         ...fetchOpts
       });

--- a/src/service/PermissionService/index.spec.ts
+++ b/src/service/PermissionService/index.spec.ts
@@ -9,6 +9,7 @@ import fetchSpy, {
   successResponse
 } from '../../spec/fetchSpy';
 import PermissionService from '.';
+import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 
 describe('PermissionService', () => {
   let fetchMock: jest.SpyInstance;
@@ -482,10 +483,12 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.setUserInstancePermission(1909, 10, 'ADMIN');
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
 
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/user/10', {
       headers: {
         Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue,
         'Content-Type': 'application/json'
       },
       body: '{\"permission\":\"ADMIN\"}',
@@ -511,11 +514,12 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.setGroupInstancePermission(1909, 10, 'ADMIN');
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/group/10', {
       headers: {
         Authorization: 'Bearer ThisIsNotAValidBearerToken',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       body: '{\"permission\":\"ADMIN\"}',
       method: 'POST'
@@ -540,11 +544,12 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.setUserClassPermission(1909, 10, 'ADMIN');
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/user/10', {
       headers: {
         Authorization: 'Bearer ThisIsNotAValidBearerToken',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       body: '{\"permission\":\"ADMIN\"}',
       method: 'POST'
@@ -569,11 +574,12 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.setGroupClassPermission(1909, 10, 'ADMIN');
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/group/10', {
       headers: {
         Authorization: 'Bearer ThisIsNotAValidBearerToken',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       body: '{\"permission\":\"ADMIN\"}',
       method: 'POST'
@@ -599,9 +605,11 @@ describe('PermissionService', () => {
 
     await service.deleteUserInstancePermission(1909, 10);
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/user/10', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -626,9 +634,11 @@ describe('PermissionService', () => {
 
     await service.deleteGroupInstancePermission(1909, 10);
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/group/10', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -652,10 +662,11 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.deleteUserClassPermission(1909, 10);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/user/10', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -680,9 +691,11 @@ describe('PermissionService', () => {
 
     await service.deleteGroupClassPermission(1909, 10);
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/group/10', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -706,10 +719,11 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.deleteUserInstancePermissions(1909);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/user', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -733,10 +747,11 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.deleteGroupInstancePermissions(1909);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/instance/group', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -760,10 +775,11 @@ describe('PermissionService', () => {
     fetchMock = fetchSpy(successResponse([]));
 
     await service.deleteUserClassPermissions(1909);
-
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/user', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });
@@ -788,9 +804,11 @@ describe('PermissionService', () => {
 
     await service.deleteGroupClassPermissions(1909);
 
+    const csrfHeaderValue = CsrfUtil.getCsrfValue();
     expect(fetchMock).toHaveBeenCalledWith('/1909/permissions/class/group', {
       headers: {
-        Authorization: 'Bearer ThisIsNotAValidBearerToken'
+        Authorization: 'Bearer ThisIsNotAValidBearerToken',
+        'X-XSRF-TOKEN': csrfHeaderValue
       },
       method: 'DELETE'
     });


### PR DESCRIPTION
See title.

In addition, `ImageFileService` (`findOneThumbnail`) has been fixed. In particular, no CRSF has to be added to headers but an auth token using  `getBearerTokenHeader`.

Plz review @terrestris/devs 