### PR TITLE
Introduces searchFeatureConfig for layer config

### DIFF
--- a/src/model/Layer.ts
+++ b/src/model/Layer.ts
@@ -55,6 +55,7 @@ export interface DownloadConfig {
 export interface SearchConfig {
   attributes?: string[];
   displayTemplate?: string;
+  resultDrawerConfig?: PropertyFormTabConfig<PropertyFormItemReadConfig>;
 }
 
 export interface DefaultLayerClientConfig {


### PR DESCRIPTION
This PR allows the configuration of a `resultDrawerConfig` within the `searchConfig` on a layer.

It is needed for https://github.com/terrestris/shogun-gis-client/pull/1943.

@terrestris/devs please review 