### PR TITLE
feat: add OGC_FEATURES layer type

### DIFF
--- a/src/model/enum/LayerType.ts
+++ b/src/model/enum/LayerType.ts
@@ -1,3 +1,3 @@
-export type LayerType = 'TILEWMS' | 'WFS' | 'WMS' | 'WMTS' | 'XYZ' | 'WMSTIME' | 'MAPBOXSTYLE' | 'MVT';
+export type LayerType = 'TILEWMS' | 'WFS' | 'OGC_FEATURES' | 'WMS' | 'WMTS' | 'XYZ' | 'WMSTIME' | 'MAPBOXSTYLE' | 'MVT';
 
 export default LayerType;

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -560,7 +560,8 @@ class SHOGunApplicationUtil<
       attribution,
       url,
       layerNames,
-      useBearerToken
+      useBearerToken,
+      requestParams = {}
     } = layer.sourceConfig || {};
 
     const {
@@ -579,9 +580,10 @@ class SHOGunApplicationUtil<
           VERSION: '2.0.0',
           REQUEST: 'GetFeature',
           TYPENAMES: layerNames,
-          OUTPUTFORMAT: 'application/json',
+          OUTPUTFORMAT: 'application/json', // TODO: This can be overriden by requestParams, but the source assumes GeoJSON
           SRSNAME: projection,
-          BBOX: `${extent.join(',')},${projection}`
+          BBOX: `${extent.join(',')},${projection}`,
+          ...requestParams
         });
 
         this.bearerTokenLoadFunctionVector(url, params, extent, !!useBearerToken, source, success, failure);
@@ -604,7 +606,8 @@ class SHOGunApplicationUtil<
     const {
       attribution,
       url,
-      useBearerToken
+      useBearerToken,
+      requestParams = {}
     } = layer.sourceConfig || {};
 
     const {
@@ -623,7 +626,8 @@ class SHOGunApplicationUtil<
         const params = UrlUtil.objectToRequestString({
           bbox: extent.join(','),
           'bbox-crs': projNum,
-          crs: projNum
+          crs: projNum,
+          ...requestParams
         });
 
         this.bearerTokenLoadFunctionVector(url, params, extent, !!useBearerToken, source, success, failure);

--- a/src/parser/SHOGunApplicationUtil.ts
+++ b/src/parser/SHOGunApplicationUtil.ts
@@ -580,7 +580,8 @@ class SHOGunApplicationUtil<
           VERSION: '2.0.0',
           REQUEST: 'GetFeature',
           TYPENAMES: layerNames,
-          OUTPUTFORMAT: 'application/json', // TODO: This can be overriden by requestParams, but the source assumes GeoJSON
+          // TODO: This can be overriden by requestParams, but the source assumes GeoJSON
+          OUTPUTFORMAT: 'application/json',
           SRSNAME: projection,
           BBOX: `${extent.join(',')},${projection}`,
           ...requestParams


### PR DESCRIPTION
This adds `OGC_FEATURES` as a layer type. Here is an example:

```json
{
  "type": "OGC_FEATURES",
  "sourceConfig": {
    "url": "/pg_featureserv/collections/public.ifm_eq/items.json"
  },
  "id": 7
}
```