### PR TITLE
Add `toolMenuWidth` to the theme

### DIFF
--- a/src/model/Application.ts
+++ b/src/model/Application.ts
@@ -28,6 +28,7 @@ export interface DefaultApplicationTheme {
   complementaryColor?: string;
   logoPath?: string;
   faviconPath?: string;
+  toolMenuWidth?: number;
 }
 
 export interface DefaultApplicationToolConfig {


### PR DESCRIPTION
This adds the field `toolMenuWidth` to the default application theme. It might be used to store the initial width of the tool menu in the GIS client.

Please review @terrestris/devs.