### PR TITLE
Introduce `getLocalizedString()`

### DIFF
--- a/src/util/getLocalizedString.spec.ts
+++ b/src/util/getLocalizedString.spec.ts
@@ -1,0 +1,34 @@
+import getLocalizedString from './getLocalizedString';
+
+describe('getLocalizedString', () => {
+  it('returns the input if no valid locale string is present', () => {
+    expect(getLocalizedString('Input', 'de')).toEqual('Input');
+    expect(getLocalizedString('$Input', 'de')).toEqual('$Input');
+    expect(getLocalizedString('$$Input', 'de')).toEqual('$$Input');
+    expect(getLocalizedString('$enInput', 'de')).toEqual('$enInput');
+    expect(getLocalizedString('en:Input', 'de')).toEqual('en:Input');
+    expect(getLocalizedString('en$:Input', 'de')).toEqual('en$:Input');
+    expect(getLocalizedString('$:Input', 'de')).toEqual('$:Input');
+    expect(getLocalizedString('$ :Input', 'de')).toEqual('$ :Input');
+    expect(getLocalizedString('$4e:Input', 'de')).toEqual('$4e:Input');
+    expect(getLocalizedString('$:Input$:Input', 'de')).toEqual('$:Input$:Input');
+    expect(getLocalizedString('$🇩🇪:Input', 'de')).toEqual('$🇩🇪:Input');
+  });
+
+  it('returns the correct locale', () => {
+    expect(getLocalizedString('$de:foo', 'de')).toEqual('foo');
+    expect(getLocalizedString('$de:Hallo$en:Hello', 'de')).toEqual('Hallo');
+    expect(getLocalizedString('$de:Hallo$en:Hello', 'en')).toEqual('Hello');
+    expect(getLocalizedString('$de:Hallo Welt$en:Hello world', 'de')).toEqual('Hallo Welt');
+    expect(getLocalizedString('$de:Hallo Welt$en:Hello world', 'en')).toEqual('Hello world');
+    expect(getLocalizedString('$de:Hallo 🌍$en:Hello 🌍', 'de')).toEqual('Hallo 🌍');
+    expect(getLocalizedString('$de:Hallo 🌍$en:Hello 🌍', 'en')).toEqual('Hello 🌍');
+    expect(getLocalizedString('$de:Hallo$de:Hello', 'de')).toEqual('Hallo');
+  });
+
+  it('returns an empty string if the requested locale is not present', () => {
+    expect(getLocalizedString('$de:Hallo', 'en')).toEqual('');
+    expect(getLocalizedString('$en:Hello', 'de')).toEqual('');
+    expect(getLocalizedString('$de:Hallo$fr:Bonjour', 'en')).toEqual('');
+  });
+});

--- a/src/util/getLocalizedString.ts
+++ b/src/util/getLocalizedString.ts
@@ -1,0 +1,33 @@
+/**
+ * Returns the localized version of the given string for the given locale.
+ *
+ * If either no localization pattern or no localized version is found
+ * the original string is returned or an empty string is returned respectively.
+ *
+ * @param str The string to localize, it may contain localization
+ *            patterns like "$de:German Text$en:English Text".
+ * @param locale The locale to use, defaults to 'en'.
+ *
+ * @returns The localized string or the original string if no localization.
+ */
+export const getLocalizedString = (str?: string, locale = 'en') => {
+  if (!str) {
+    return '';
+  }
+
+  // Check if string contains localization pattern at all.
+  if (!str.match(/\$([a-zA-Z]+):([^$]+)/)) {
+    return str;
+  }
+
+  const regex = new RegExp(`\\$${locale}:([^$]+)`, 'g');
+  const result = regex.exec(str);
+
+  if (!result) {
+    return '';
+  }
+
+  return result[1];
+};
+
+export default getLocalizedString;


### PR DESCRIPTION
In preparation for translatable text snippets (e.g. application's name) this util resolves the _planned_ placeholders like `$de:German Text$en:English Text`.

Please review @terrestris/devs.