### PR TITLE
Configurable page size for findAll 

### DIFF
--- a/src/service/GenericEntityService/index.ts
+++ b/src/service/GenericEntityService/index.ts
@@ -14,10 +14,10 @@ export abstract class GenericEntityService<T extends BaseEntity> extends Permiss
     super(opts);
   }
 
-  async findAllNoPaging(fetchOpts?: RequestInit): Promise<T[]> {
+  async findAllNoPaging(fetchOpts?: RequestInit, pageSize = 10): Promise<T[]> {
     const pageOpts: PageOpts = {
       page: 0,
-      size: 10
+      size: pageSize
     };
     let list: T[] = [];
     try {

--- a/src/service/GenericEntityService/index.ts
+++ b/src/service/GenericEntityService/index.ts
@@ -36,7 +36,7 @@ export abstract class GenericEntityService<T extends BaseEntity> extends Permiss
 
         const result = await response.json() as Page<T>;
         list = list.concat(result.content);
-        if ((pageOpts.page as number) < result.totalPages) {
+        if ((pageOpts.page as number + 1) < result.totalPages) {
           (pageOpts.page as number) += 1;
         } else {
           break;


### PR DESCRIPTION
- This allows to set a larger page size, e.g. for applications with a large number of layers. The previous value is used as a default, so this should not result in any breaking changes.
- Also fixes a bug: The last request was always empty because of an index issue.

@terrestris/devs Please review.